### PR TITLE
fix: dead links

### DIFF
--- a/content/6.core/12.Outbound.md
+++ b/content/6.core/12.Outbound.md
@@ -46,7 +46,7 @@ Default: true. Switch to false to disable TLS for outbound mail.
 
 This uses the same `tls_key.pem` and `tls_cert.pem` files that the `tls`
 plugin uses, along with other values in `tls.ini`. See the [tls plugin
-docs](http://haraka.github.io/manual/plugins/tls.html) for information on generating those
+docs](/plugins/tls) for information on generating those
 files.
 
 Within `tls.ini` you can specify global options for the values `ciphers`,

--- a/content/6.core/15.Transaction.md
+++ b/content/6.core/15.Transaction.md
@@ -172,7 +172,7 @@ body in the same encoding.
 
 * transaction.results
 
-Store results of processing in a structured format. See [docs/Results](http://haraka.github.io/manual/Results.html)
+Store results of processing in a structured format. See [docs/Results](/core/Results)
 
 [1]: `Address` objects are address-rfc2821 objects. See https://github.com/haraka/node-address-rfc2821
 

--- a/content/8.plugins.md
+++ b/content/8.plugins.md
@@ -134,7 +134,7 @@ Create a PR adding yours to this list.
 [url-p0f]: https://github.com/haraka/haraka-plugin-p0f
 [url-headers]: https://github.com/haraka/haraka-plugin-headers
 [url-sigs]: https://github.com/haraka/Haraka/blob/master/docs/plugins/data.signatures.md
-[url-uribl]: https://github.com/haraka/Haraka/blob/master/docs/plugins/data.uribl.md
+[url-uribl]: https://github.com/haraka/haraka-plugin-uribl
 [url-dcc]: https://github.com/haraka/haraka-plugin-dcc
 [url-delay]: https://github.com/haraka/Haraka/blob/master/docs/plugins/delay_deny.md
 [url-sign]: https://github.com/haraka/Haraka/blob/master/docs/plugins/dkim_sign.md

--- a/content/8.plugins/avg.md
+++ b/content/8.plugins/avg.md
@@ -6,7 +6,7 @@ navigation.title: avg
 
 # Avg plugin
 
-Implement virus scanning with AVG's TCPD daemon, available for Linux/FreeBSD. AVG linux is [free for personal or commercial use](http://www.avg.com/gb-en/faq.pnuid-faq_v3_linux) and can be downloaded from [free.avg.com](http://free.avg.com/gb-en/download.prd-alf).
+Implement virus scanning with AVG's legacy TCPD daemon which was available for Linux/FreeBSD.
 
 Messages that AVG detects as infected are rejected. Errors will cause the plugin to return temporary failures unless the defer options are changed (see below).
 

--- a/content/8.plugins/connect.asn.md
+++ b/content/8.plugins/connect.asn.md
@@ -74,7 +74,7 @@ connections, and should be handled with increased scrutiny.
 
 ## Research
 
-http://www.cc.gatech.edu/~feamster/papers/snare-usenix09.pdf
+[http://www.cc.gatech.edu/~feamster/papers/snare-usenix09.pdf](http://web.archive.org/web/20090709150921/http://www.cc.gatech.edu/~feamster/papers/snare-usenix09.pdf)
 
 "Performance based on AS number only...The classifier gets a false positive
 rate of 0.76% [and] a 70% detection rate"

--- a/content/8.plugins/connect.geoip.md
+++ b/content/8.plugins/connect.geoip.md
@@ -108,7 +108,7 @@ This plugin does not update the GeoIP databases. You may want to.
 
 MaxMind: http://www.maxmind.com/
 
-Databases: http://geolite.maxmind.com/download/geoip/database
+Databases: https://dev.maxmind.com/geoip/geolite2-free-geolocation-data
 
 
 # TODO

--- a/content/8.plugins/messagesniffer.md
+++ b/content/8.plugins/messagesniffer.md
@@ -6,7 +6,7 @@ navigation.title: messagesniffer
 
 # messagesniffer plugin
 
-This plugin provides integration with the commerical Anti-Spam product [MessageSniffer](http://armresearch.com/products/sniffer.jsp) by Arm Research Labs using its XML Client interface [XCI](http://armresearch.com/support/articles/software/snfServer/xci/) over TCP.
+This plugin provides integration with the commerical Anti-Spam product [MessageSniffer](http://armresearch.com/Products/SNFforNix.jsp) by Arm Research Labs using its XML Client interface XCI over TCP.
 
 Installation
 ------------

--- a/content/8.plugins/relay.md
+++ b/content/8.plugins/relay.md
@@ -14,7 +14,7 @@ This **relay** plugin provides Haraka with options for managing relay permission
 
 ## Authentication
 
-One way to enable relaying is [authentication](http://haraka.github.io/manual.html) via the auth plugins. Successful authentication enables relaying during _that_ SMTP connection. To securely offer SMTP AUTH, the [tls](http://haraka.github.io/manual/plugins/tls.html) plugin and at least one auth plugin must be enabled and properly configured. When that requirement is met, the AUTH SMTP extension will be advertised to SMTP clients.
+One way to enable relaying is [authentication](/core/Plugins) via the auth plugins. Successful authentication enables relaying during _that_ SMTP connection. To securely offer SMTP AUTH, the [tls](/plugins/tls) plugin and at least one auth plugin must be enabled and properly configured. When that requirement is met, the AUTH SMTP extension will be advertised to SMTP clients.
 
 ```
 % nc mail.example.com 587

--- a/content/8.plugins/rspamd.md
+++ b/content/8.plugins/rspamd.md
@@ -98,7 +98,7 @@ rspamd.ini
 
     Default: true
 
-    If set to true, allow rspamd to add/remove headers to messages via [task:rmilter_set_reply()](https://rspamd.com/doc/lua/task.html#me7351).
+    If set to true, allow rspamd to add/remove headers to messages via [task:rmilter_set_reply()](https://www.rspamd.com/doc/modules/milter_headers.html).
 
 - soft\_reject.enabled
 

--- a/content/8.plugins/spf.md
+++ b/content/8.plugins/spf.md
@@ -80,7 +80,7 @@ openspf_text = true
   reject messages that explicitely fail SPF tests. SPF failures have a high
   correlation with spam. However, up to 10% of ham transits forwarders and/or
   email lists which frequently break SPF. SPF results are best used as inputs
-  to other plugins such as DMARC, [spamassassin](http://haraka.github.io/manual/plugins/spamassassin.html), and [karma](/plugins/karma).
+  to other plugins such as DMARC, [spamassassin](/plugins/spamassassin), and [karma](/plugins/karma).
 
 * Heed well the implications of SPF, as described in [RFC 4408](http://tools.ietf.org/html/rfc4408#section-9.3)
 


### PR DESCRIPTION
Hello,

There are a few more dead links that I'll need some help.

1. http://www.avg.com/gb-en/faq.pnuid-faq_v3_linux
https://github.com/haraka/haraka.github.io/blob/8619315d23eca99047dc8a581228fdb73e01d109/content/8.plugins/avg.md?plain=1#L9

As I understand AVG doesn't provide any more linux dist?

___
2. http://www.cc.gatech.edu/~feamster/papers/snare-usenix09.pdf https://github.com/haraka/haraka.github.io/blob/8619315d23eca99047dc8a581228fdb73e01d109/content/8.plugins/connect.asn.md?plain=1#L77

Link this to [web.archive.org](http://web.archive.org/web/20090709150921/http://www.cc.gatech.edu/~feamster/papers/snare-usenix09.pdf) instead?

____
3. https://rspamd.com/doc/lua/task.html#me7351

https://github.com/haraka/haraka.github.io/blob/master/content/8.plugins/rspamd.md?plain=1#L101

Looking at this rspamd has changed function name, similar function is `task:set_milter_reply` is it correct? https://www.rspamd.com/doc/lua/rspamd_task.html#m70081

____
4. http://armresearch.com/products/sniffer.jsp & http://armresearch.com/support/articles/software/snfServer/xci

https://github.com/haraka/haraka.github.io/blob/8619315d23eca99047dc8a581228fdb73e01d109/content/8.plugins/messagesniffer.md?plain=1#L9

What I should to with those 2 links?

____

Thanks!