### PR TITLE
fix: add header back

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -6,6 +6,9 @@ export default defineAppConfig({
     socials: {
       github: 'haraka/Haraka',
     },
+    header: {
+      logo: true,
+    },
     aside: {
       level: 0,
       collapsed: true,


### PR DESCRIPTION
Well, after new update docus has now setting header logo to false, so this PR is making it shine back again.