### PR TITLE
chore: remove slack link

### DIFF
--- a/content/1.getting_started.md
+++ b/content/1.getting_started.md
@@ -45,8 +45,7 @@ queued for outbound delivery.
 ### Getting Help
 
 * [Join the mailing list][8] (implemented as a Haraka plugin)
-* [Join us on Slack][14]
-* [GitHub Issues][15]
+* [GitHub Issues][14]
 
 
 ### Screencast
@@ -171,9 +170,9 @@ node haraka.js
 
 ### License and Author
 
-Haraka is MIT licensed - see the [LICENSE][16] file for details.
+Haraka is MIT licensed - see the [LICENSE][15] file for details.
 
-Haraka is a project started by [Matt Sergeant][17], a 10 year veteran of the email
+Haraka is a project started by [Matt Sergeant][16], a 10 year veteran of the email
 and anti-spam world. Previous projects have been the project leader for
 SpamAssassin and a hacker on [Qpsmtpd][13].
 
@@ -189,7 +188,6 @@ SpamAssassin and a hacker on [Qpsmtpd][13].
 [11]: https://haraka.github.io/plugins/dnsbl/
 [12]: https://github.com/haraka/Haraka/tree/master/plugins
 [13]: https://github.com/smtpd/qpsmtpd/
-[14]: https://communityinviter.com/apps/harakaserver/public-inviter
-[15]: https://github.com/haraka/Haraka/issues
-[16]: https://github.com/haraka/Haraka/blob/master/LICENSE
-[17]: https://github.com/baudehlo
+[14]: https://github.com/haraka/Haraka/issues
+[15]: https://github.com/haraka/Haraka/blob/master/LICENSE
+[16]: https://github.com/baudehlo


### PR DESCRIPTION
Slack link is still in getting started page.